### PR TITLE
Fix vapoursynth library search paths not working in Qt6 for Windows.

### DIFF
--- a/common-src/vapoursynth/vs_script_library.cpp
+++ b/common-src/vapoursynth/vs_script_library.cpp
@@ -226,6 +226,7 @@ bool VSScriptLibrary::initLibrary()
 
 		if(!libraryFullPath.isEmpty())
 		{
+			m_vsScriptLibrary.unload();
 			m_vsScriptLibrary.setFileName(libraryFullPath);
 			loaded = m_vsScriptLibrary.load();
 		}
@@ -238,6 +239,7 @@ bool VSScriptLibrary::initLibrary()
 			m_pSettingsManager->getVapourSynthLibraryPaths();
 		for(const QString & path : librarySearchPaths)
 		{
+			m_vsScriptLibrary.unload();
 			libraryFullPath = vsedit::resolvePathFromApplication(path) +
 				QString("/") + libraryName;
 			m_vsScriptLibrary.setFileName(libraryFullPath);

--- a/vsedit/src/vapoursynth/vapoursynth_plugins_manager.cpp
+++ b/vsedit/src/vapoursynth/vapoursynth_plugins_manager.cpp
@@ -123,6 +123,7 @@ void VapourSynthPluginsManager::getCorePlugins()
 
 		if(!libraryFullPath.isEmpty())
 		{
+			vsLibrary.unload();
 			vsLibrary.setFileName(libraryFullPath);
 			loaded = vsLibrary.load();
 		}
@@ -135,6 +136,7 @@ void VapourSynthPluginsManager::getCorePlugins()
 			m_pSettingsManager->getVapourSynthLibraryPaths();
 		for(const QString & path : librarySearchPaths)
 		{
+			vsLibrary.unload();
 			libraryFullPath = vsedit::resolvePathFromApplication(path) +
 				QString("/") + libraryName;
 			vsLibrary.setFileName(libraryFullPath);


### PR DESCRIPTION
It seems `vsLibrary.load()` will never return true if it failed before. This causes values in "library search paths" item not to work at all. Calling `vsLibrary.unload()` before `vsLibrary.setFileName()` is a workaround for this issue.

I found this in Qt6 build on Windows. Not sure if *nix systems will have the same issue. I'm not a *nix user so you may need to confirm this change will not affect other systems.