### PR TITLE
Update syntax highlighting for python 3.10.

### DIFF
--- a/vsedit/src/script_editor/syntax_highlighter.cpp
+++ b/vsedit/src/script_editor/syntax_highlighter.cpp
@@ -63,11 +63,11 @@ SyntaxHighlighter::SyntaxHighlighter(QTextDocument * a_pDocument,
 	, m_vsArgumentFormat()
 {
 	m_keywordsList << "False" << "None" << "True" << "and" << "as" <<
-		"assert" << "break" << "class" << "continue" << "def" << "del" <<
-		"elif" << "else" << "except" << "finally" << "for" << "from" <<
-		"global" << "if" << "import" << "in" << "is" << "lambda" <<
-		"nonlocal" << "not" << "or" << "pass" << "raise" << "return" <<
-		"try" << "while" << "with" << "yield";
+                "assert" << "break" << "case" << "class" << "continue" << "def" <<
+                "del" << "elif" << "else" << "except" << "finally" << "for" <<
+                "from" << "global" << "if" << "import" << "in" << "is" << "lambda" <<
+                "match" << "nonlocal" << "not" << "or" << "pass" << "raise" <<
+                "return" << "try" << "while" << "with" << "yield";
 
 	// MUST be sorted by length in descending order.
 	m_operatorsList << "//=" << ">>=" << "<<=" << "**=" << "**" << "//" <<


### PR DESCRIPTION
Python 3.10 introduced match/case statements in PEP 634. Add these to syntax highlighting.