### PR TITLE
Make "Home" toggle between the block start and the first column

### DIFF
--- a/vsedit/src/script_editor/script_editor.cpp
+++ b/vsedit/src/script_editor/script_editor.cpp
@@ -439,7 +439,8 @@ void ScriptEditor::slotHome(bool a_select)
 	int blockLength = firstBlock.text().length();
 	if(blockLength == 0)
 		return;
-	int position = firstBlock.position();
+	int blockStart = firstBlock.position();
+        int position = blockStart;
 	int endPosition = cursor.selectionEnd();
 	for(int i = 0; i < blockLength; ++i)
 	{
@@ -448,7 +449,10 @@ void ScriptEditor::slotHome(bool a_select)
 			break;
 		position++;
 	}
-	cursor.setPosition(position);
+        if(position == cursor.position())
+            cursor.setPosition(blockStart);
+        else
+            cursor.setPosition(position);
 	if(a_select)
 		cursor.setPosition(endPosition, QTextCursor::KeepAnchor);
 	setTextCursor(cursor);


### PR DESCRIPTION
Sometimes, "Home" really means the first column, in particular when you want to mark a block for copy/cut/paste. This patch keeps the original behaviour for the first time "Home" is pressed, and alternates between the first column and the beginning of the block for all further presses.